### PR TITLE
[ISSUE-44] Get commit SHA from pull_request.merge_commit_sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ GitHub Cherry Pick Action will:
 - Push new `branch` to remote
 - Open pull request to `branch`
 
+> *NOTE:* The `GITHUB_SHA` is taken from the GitHub context, specifically from the `merge_commit_sha` attribute of the pull request object.
+
 ## Example
 
 Cherry-picking pull requests merged on main to branch *release-v1.0* in pull requests labeled with **release-v1.0** and to branch *release-v2.0* in pull requests labeled with **release-v2.0**.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import * as core from '@actions/core'
 import * as io from '@actions/io'
 import * as exec from '@actions/exec'
 import * as utils from './utils'
+import * as github from '@actions/github'
 import {Inputs, createPullRequest} from './github-helper'
+import { PullRequest } from '@octokit/webhooks-definitions/schema'
 
 const CHERRYPICK_EMPTY =
   'The previous cherry-pick is now empty, possibly due to conflict resolution.'
@@ -27,7 +29,9 @@ export async function run(): Promise<void> {
 
     core.info(`Cherry pick into branch ${inputs.branch}!`)
 
-    const githubSha = process.env.GITHUB_SHA
+    // the value of merge_commit_sha changes depending on the status of the pull request
+    // see https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+    const githubSha = (github.context.payload.pull_request as PullRequest).merge_commit_sha
     const prBranch = inputs.cherryPickBranch
       ? inputs.cherryPickBranch
       : `cherry-pick-${inputs.branch}-${githubSha}`

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,8 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import {run} from '../src/index'
-import {createPullRequest, Inputs} from '../src/github-helper'
+import {createPullRequest} from '../src/github-helper'
+import { PullRequest } from '@octokit/webhooks-definitions/schema'
 
 const defaultMockedGetInputData: any = {
   token: 'whatever',
@@ -43,6 +44,18 @@ jest.mock('@actions/exec', () => {
   }
 })
 
+jest.mock('@actions/github', () => {
+  return {
+    context: {
+      payload: {
+        pull_request: {
+          merge_commit_sha: 'XXXXXX'
+        } as PullRequest
+      }
+    }
+  }
+})
+
 jest.mock('../src/github-helper', () => {
   return {
     createPullRequest: jest.fn().mockImplementation(() => {
@@ -53,7 +66,6 @@ jest.mock('../src/github-helper', () => {
 
 describe('run main', () => {
   beforeEach(() => {
-    process.env.GITHUB_SHA = 'xxxxxxxxxx'
     mockedGetInputData = defaultMockedGetInputData
   })
 
@@ -86,7 +98,7 @@ describe('run main', () => {
   test('valid execution with default new branch', async () => {
     await run()
 
-    commonChecks('target-branch', 'cherry-pick-target-branch-xxxxxxxxxx')
+    commonChecks('target-branch', 'cherry-pick-target-branch-XXXXXX')
 
     expect(createPullRequest).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -99,7 +111,7 @@ describe('run main', () => {
         reviewers: [],
         cherryPickBranch: ''
       }),
-      'cherry-pick-target-branch-xxxxxxxxxx'
+      'cherry-pick-target-branch-XXXXXX'
     )
   })
 


### PR DESCRIPTION
Fixes https://github.com/carloscastrojumo/github-cherry-pick-action/issues/44

As per linked issue, this PR aims to update the way in which the commit SHA to be cherry picked is retrieved.

Instead of getting it from `process.env.GITHUB_SHA`, it retrieves that SHA from `contex.payload.pull_request.merge_commit_sha`, whose value change depending on the pull request status [1]

In this way it is possible to cherry-pick pull requests that have merged some time ago, even if new commits have been added on top of the original PR's target branch. This was not possible if using `pull_request_target` workflow.

[1] https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request