### PR TITLE
Fix typo in team reviewers input parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export async function run(): Promise<void> {
       inherit_labels: utils.getInputAsBoolean('inherit_labels'),
       assignees: utils.getInputAsArray('assignees'),
       reviewers: utils.getInputAsArray('reviewers'),
-      teamReviewers: utils.getInputAsArray('teamReviewers'),
+      teamReviewers: utils.getInputAsArray('team-reviewers'),
       cherryPickBranch: core.getInput('cherry-pick-branch')
     }
 


### PR DESCRIPTION
There was a typo in the team reviewers input parameter which cause it didn't work.

This change will break the retro-compatibility with previous versions if someone is adding team reviewers using `teamReviewers` parameter. The option to maintain it is changing the parameter name to `teamReviewers`, I can do it if you prefer this second option.